### PR TITLE
Increase energy buffer of RS to allow larger single systems.

### DIFF
--- a/config/refinedstorage.cfg
+++ b/config/refinedstorage.cfg
@@ -2,7 +2,7 @@
 
 controller {
     # The energy capacity of the Controller [range: 0 ~ 2147483647, default: 32000]
-    I:capacity=32000
+    I:capacity=2000000
 
     # Whether the Controller uses energy [default: true]
     B:usesEnergy=true


### PR DESCRIPTION
Mostly fixes large reborn storage multiblocks from being completely unusable due to having higher energy usage than the buffer

Closes #13 