### PR TITLE
fix(config): advancedrocketry overworld skybox

### DIFF
--- a/config/advRocketry/advancedRocketry.cfg
+++ b/config/advRocketry/advancedRocketry.cfg
@@ -56,6 +56,7 @@ client {
 
     # If UI is not locked, the middle mouse can be used to drag certain AR UIs around the screen, positions are saved on hitting quit in the menu
     B:lockUI=true
+    B:overworldSkyOverride=false
     I:oxygenBarModeX=0
     I:oxygenBarModeY=1
     I:oxygenBarX=-8


### PR DESCRIPTION
Advanced Rocketry overworld sky-box override causes sky display glitches, when standing below sea level (sky becomes dark blue), and lighting becomes washed-out when standing below blocks where skylight is dimmed.

Disabling `overworldSkyOverride` restores vanilla sky box for overworld and, get ride of all the sky and lighting glitches cited above.

```YAML
    B:overworldSkyOverride=false
```