### PR TITLE
EverlastingAbilities entities blacklist

### DIFF
--- a/config/everlastingabilities.cfg
+++ b/config/everlastingabilities.cfg
@@ -419,6 +419,46 @@ general {
     # The amount of exhaustion that should by applied to the player per active ability per second.
     D:general.exhaustionPerAbilityTick=0.01
 
+    # These mobs will not be affected by hostile area potion effects such as poison or weakness. (Java regular expressions are allowed)
+    S:general.friendlyMobs <
+        minecraft:villager
+        minecraft:villager_golem
+        minecraft:cow
+        minecraft:sheep
+        minecraft:pig
+        minecraft:chicken
+        minecraft:rabbit
+        minecraft:mooshroom
+        minecraft:horse
+        minecraft:donkey
+        minecraft:mule
+        minecraft:llama
+        minecraft:ocelot
+        minecraft:parrot
+        minecraft:wolf
+        farmingforblockheads:merchant
+        forestry:butterflyge
+        mekanism:robit
+        openblocks:cartographer
+        openblocks:golden_eye
+        openblocks:luggage
+        openblocks:xp_orb_no_fly
+        opencomputers:drone
+        randomthings:goldenchicken
+        randomthings:playersoul
+        thaumcraft:golem
+        thaumcraft:pech
+        twilightforest:bighorn_sheep
+        twilightforest:bunny
+        twilightforest:deer
+        twilightforest:penguin
+        twilightforest:quest_ram
+        twilightforest:raven
+        twilightforest:squirrel
+        twilightforest:tiny_bird
+        twilightforest:wild_boar
+    >
+
     # If the magnetize ability should move xp.
     B:general.magnetizeMoveXp=true
 


### PR DESCRIPTION
Added some neutral/friendly living entities to the EverlastingAbilities entity effect blacklist.

```YAML
    # These mobs will not be affected by hostile area potion effects such as poison or weakness. (Java regular expressions are allowed)
    S:general.friendlyMobs <
    ...
    >
```