### PR TITLE
Fix world corruption crash with AE2 Energy Cells

### DIFF
--- a/config/flux_networks.cfg
+++ b/config/flux_networks.cfg
@@ -1,5 +1,22 @@
 # Configuration file
 
+blacklists {
+    # a blacklist for blocks which flux connections shouldn't connect to, use format 'modid:name'
+    S:"Block Connection Blacklist" <
+        actuallyadditions:block_phantom_energyface
+        appliedenergistics2:energy_acceptor
+        appliedenergistics2:dense_energy_cell
+        appliedenergistics2:energy_cell 
+     >
+
+    # a blacklist for items which the Flux Controller shouldn't transfer to, use format 'modid:name'
+    S:"Item Transfer Blacklist" <
+        appliedenergistics2:energy_acceptor
+        appliedenergistics2:dense_energy_cell
+        appliedenergistics2:energy_cell 
+     >
+}
+
 energy {
     #  [range: 0 ~ 2147483647, default: 256000]
     I:"Basic Storage Capacity"=256000


### PR DESCRIPTION
Blacklist AppliedEnergistics2 Energy Cells from the flux network to prevent world corruption crashes as recommended here:
https://github.com/AppliedEnergistics/Applied-Energistics-2/issues/4012#issuecomment-503993344